### PR TITLE
투표 게시글에 투표 항목을 같이 저장하도록 기능 추가 개발

### DIFF
--- a/src/main/java/fun/config/AuthArgumentResolverConfig.java
+++ b/src/main/java/fun/config/AuthArgumentResolverConfig.java
@@ -1,7 +1,7 @@
 package fun.config;
 
 import fun.domain.auth.config.argument.AuthAccessArgumentResolver;
-import org.springframework.context.annotation.Bean;
+import fun.domain.auth.config.argument.AuthRefreshArgumentResolver;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -13,11 +13,7 @@ public class AuthArgumentResolverConfig implements WebMvcConfigurer {
 
     @Override
     public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
-        resolvers.add(authArgumentResolver());
-    }
-
-    @Bean
-    AuthAccessArgumentResolver authArgumentResolver() {
-        return new AuthAccessArgumentResolver();
+        resolvers.add(new AuthAccessArgumentResolver());
+        resolvers.add(new AuthRefreshArgumentResolver());
     }
 }

--- a/src/main/java/fun/domain/auth/config/argument/AuthAccessArgumentResolver.java
+++ b/src/main/java/fun/domain/auth/config/argument/AuthAccessArgumentResolver.java
@@ -1,6 +1,7 @@
 package fun.domain.auth.config.argument;
 
 import fun.common.auth.AuthAccessToken;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.core.MethodParameter;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -26,7 +27,10 @@ public class AuthAccessArgumentResolver implements HandlerMethodArgumentResolver
             final NativeWebRequest webRequest,
             final WebDataBinderFactory binderFactory
     ) throws Exception {
-        return Optional.ofNullable(webRequest.getAttribute(AUTHORIZATION_ACCESS_TOKEN, 0))
+        final HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        final Object authAccessTokenValue = request.getAttribute(AUTHORIZATION_ACCESS_TOKEN);
+
+        return Optional.ofNullable(authAccessTokenValue)
                 .filter(value -> value instanceof Long)
                 .map(value -> new AuthAccessToken((Long) value))
                 .orElseThrow(() -> new IllegalArgumentException("사용자 식별자 값이 존재하지 않습니다."));

--- a/src/main/java/fun/domain/auth/config/argument/AuthRefreshArgumentResolver.java
+++ b/src/main/java/fun/domain/auth/config/argument/AuthRefreshArgumentResolver.java
@@ -1,6 +1,7 @@
 package fun.domain.auth.config.argument;
 
 import fun.common.auth.AuthRefreshToken;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.core.MethodParameter;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -26,7 +27,10 @@ public class AuthRefreshArgumentResolver implements HandlerMethodArgumentResolve
             final NativeWebRequest webRequest,
             final WebDataBinderFactory binderFactory
     ) throws Exception {
-        return Optional.ofNullable(webRequest.getAttribute(AUTHORIZATION_REFRESH_TOKEN, 0))
+        final HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        final Object authRefreshTokenValue = request.getAttribute(AUTHORIZATION_REFRESH_TOKEN);
+
+        return Optional.ofNullable(authRefreshTokenValue)
                 .filter(value -> value instanceof String)
                 .map(value -> new AuthRefreshToken((String) value))
                 .orElseThrow(() -> new IllegalArgumentException("리프래시 토큰 값이 존재하지 않습니다."));

--- a/src/main/java/fun/domain/vote/item/domain/VoteCount.java
+++ b/src/main/java/fun/domain/vote/item/domain/VoteCount.java
@@ -1,0 +1,37 @@
+package fun.domain.vote.item.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+
+import java.util.Objects;
+
+@Getter
+@Embeddable
+public class VoteCount {
+
+    public static final VoteCount ZERO = new VoteCount(0);
+
+    @Column(name = "count", nullable = false)
+    private Integer value;
+
+    protected VoteCount() {
+    }
+
+    public VoteCount(final Integer value) {
+        this.value = value;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final VoteCount voteCount = (VoteCount) o;
+        return Objects.equals(value, voteCount.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+}

--- a/src/main/java/fun/domain/vote/item/domain/VoteItem.java
+++ b/src/main/java/fun/domain/vote/item/domain/VoteItem.java
@@ -1,0 +1,65 @@
+package fun.domain.vote.item.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import lombok.Getter;
+
+@Getter
+@Entity
+public class VoteItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    @Embedded
+    private VoteCount voteCount;
+
+    @JoinColumn(name = "vote_post_id", nullable = false)
+    private Long votePostId;
+
+    protected VoteItem() {
+    }
+
+    public VoteItem(final String content) {
+        this(null, content, VoteCount.ZERO, null);
+    }
+
+    protected VoteItem(
+            final Long id,
+            final String content,
+            final VoteCount voteCount,
+            final Long votePostId
+    ) {
+        this.id = id;
+        this.content = content;
+        this.voteCount = voteCount;
+        this.votePostId = votePostId;
+    }
+
+    public void assignVotePost(final Long requestVotePostId) {
+        if (this.votePostId != null) {
+            throw new IllegalStateException("현재 투표 항목은 이미 투표 게시글에 속해 있습니다.");
+        }
+
+        this.votePostId = requestVotePostId;
+    }
+
+    @Override
+    public String toString() {
+        return "VoteItem{" +
+               "id=" + id +
+               ", content='" + content + '\'' +
+               ", voteCount=" + voteCount +
+               ", votePostId=" + votePostId +
+               '}';
+    }
+}

--- a/src/main/java/fun/domain/vote/post/controller/command/VotePostCommandController.java
+++ b/src/main/java/fun/domain/vote/post/controller/command/VotePostCommandController.java
@@ -1,6 +1,7 @@
 package fun.domain.vote.post.controller.command;
 
 import fun.common.auth.AuthAccessToken;
+import fun.domain.auth.config.argument.AuthAccessPrinciple;
 import fun.domain.vote.post.service.command.VotePostCommandService;
 import fun.domain.vote.post.service.command.request.CreateVotePostRequest;
 import lombok.RequiredArgsConstructor;
@@ -20,9 +21,13 @@ public class VotePostCommandController {
     private final VotePostCommandService votePostCommandService;
 
     @PostMapping
-    ResponseEntity<Void> createVotePost(@RequestBody final CreateVotePostRequest createVotePostRequest) {
+    ResponseEntity<Void> createVotePost(
+            @AuthAccessPrinciple final AuthAccessToken authAccessToken,
+            @RequestBody final CreateVotePostRequest createVotePostRequest
+    ) {
         final Long savedVotePostId = votePostCommandService.createVotePost(
-                new AuthAccessToken(1L), createVotePostRequest
+                authAccessToken.memberId(),
+                createVotePostRequest
         );
 
         return ResponseEntity

--- a/src/main/java/fun/domain/vote/post/domain/VotePost.java
+++ b/src/main/java/fun/domain/vote/post/domain/VotePost.java
@@ -1,5 +1,6 @@
 package fun.domain.vote.post.domain;
 
+import fun.domain.vote.item.domain.VoteItem;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
@@ -11,6 +12,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import lombok.Getter;
 
@@ -35,6 +37,9 @@ public class VotePost {
     @Embedded
     private DueDate dueDate;
 
+    @OneToMany(mappedBy = "votePostId", cascade = CascadeType.PERSIST, orphanRemoval = true)
+    private List<VoteItem> voteItems = new ArrayList<>();
+
     @JoinColumn(name = "vote_tag_id")
     @OneToOne(cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
     private VoteTag voteTag;
@@ -43,7 +48,7 @@ public class VotePost {
     @CollectionTable(name = "vote_post_vote_label", joinColumns = @JoinColumn(name = "vote_post_id"))
     private List<Long> voteLabelIds = new ArrayList<>();
 
-    @Column(name = "member_id", nullable = false)
+    @Column(name = "member_id")
     private Long memberId;
 
     protected VotePost() {
@@ -53,10 +58,9 @@ public class VotePost {
             final String title,
             final String content,
             final DueDate dueDate,
-            final VoteTag voteTag,
-            final List<Long> voteLabelIds
+            final VoteTag voteTag
     ) {
-        this(null, title, content, dueDate, voteTag, voteLabelIds);
+        this(null, title, content, dueDate, new ArrayList<>(), voteTag, new ArrayList<>());
     }
 
     protected VotePost(
@@ -64,6 +68,7 @@ public class VotePost {
             final String title,
             final String content,
             final DueDate dueDate,
+            final List<VoteItem> voteItems,
             final VoteTag voteTag,
             final List<Long> voteLabelIds
     ) {
@@ -71,6 +76,7 @@ public class VotePost {
         this.title = title;
         this.content = content;
         this.dueDate = dueDate;
+        this.voteItems = voteItems;
         this.voteTag = voteTag;
         this.voteLabelIds = voteLabelIds;
     }
@@ -81,6 +87,13 @@ public class VotePost {
     ) {
         voteAssignHostValidator.validate(requestMemberId);
         this.memberId = requestMemberId;
+    }
+
+    public void addVoteItems(final List<VoteItem> requestVoteItems) {
+        for (final VoteItem requestVoteItem : requestVoteItems) {
+            requestVoteItem.assignVotePost(this.id);
+        }
+        this.voteItems.addAll(requestVoteItems);
     }
 
     @Override
@@ -94,5 +107,19 @@ public class VotePost {
     @Override
     public int hashCode() {
         return Objects.hash(id);
+    }
+
+    @Override
+    public String toString() {
+        return "VotePost{" +
+               "id=" + id +
+               ", title='" + title + '\'' +
+               ", content='" + content + '\'' +
+               ", dueDate=" + dueDate +
+               ", voteItems=" + voteItems +
+               ", voteTag=" + voteTag +
+               ", voteLabelIds=" + voteLabelIds +
+               ", memberId=" + memberId +
+               '}';
     }
 }

--- a/src/main/java/fun/domain/vote/post/service/command/VotePostCommandService.java
+++ b/src/main/java/fun/domain/vote/post/service/command/VotePostCommandService.java
@@ -1,18 +1,19 @@
 package fun.domain.vote.post.service.command;
 
-import fun.common.auth.AuthAccessToken;
+import fun.domain.vote.item.domain.VoteItem;
 import fun.domain.vote.post.domain.DueDate;
 import fun.domain.vote.post.domain.VoteAssignHostValidator;
 import fun.domain.vote.post.domain.VotePost;
 import fun.domain.vote.post.domain.VotePostCommandRepository;
-import fun.domain.vote.post.service.command.request.CreateVotePostRequest;
 import fun.domain.vote.post.domain.VoteTag;
 import fun.domain.vote.post.domain.VoteTagCommandRepository;
+import fun.domain.vote.post.service.command.request.CreateVotePostRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Transactional
@@ -23,19 +24,30 @@ public class VotePostCommandService {
     private final VoteTagCommandRepository voteTagCommandRepository;
     private final VoteAssignHostValidator voteAssignHostValidator;
 
-    public Long createVotePost(final AuthAccessToken authAccessToken, final CreateVotePostRequest votePostRequest) {
+    public Long createVotePost(
+            final Long requestMemberId,
+            final CreateVotePostRequest votePostRequest
+    ) {
         final VoteTag findVoteTag = voteTagCommandRepository.getVoteTagById(votePostRequest.tagId());
-        final DueDate dueDate = new DueDate(votePostRequest.localDateTime());
-
-        final VotePost newVotePost = new VotePost(
-                votePostRequest.title(),
-                votePostRequest.content(),
-                dueDate,
-                findVoteTag,
-                Collections.emptyList()
+        final DueDate requestDueDate = new DueDate(votePostRequest.localDateTime());
+        final VotePost savedVotePost = votePostCommandRepository.save(
+                new VotePost(
+                        votePostRequest.title(),
+                        votePostRequest.content(),
+                        requestDueDate,
+                        findVoteTag
+                )
         );
-        newVotePost.assignHost(authAccessToken.memberId(), voteAssignHostValidator);
 
-        return votePostCommandRepository.save(newVotePost).getId();
+        savedVotePost.assignHost(requestMemberId, voteAssignHostValidator);
+        savedVotePost.addVoteItems(convertToVoteItems(votePostRequest.voteItemTitles()));
+
+        return savedVotePost.getId();
+    }
+
+    private List<VoteItem> convertToVoteItems(final List<String> voteItemTitles) {
+        return voteItemTitles.stream()
+                .map(VoteItem::new)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/fun/domain/vote/post/service/command/request/CreateVotePostRequest.java
+++ b/src/main/java/fun/domain/vote/post/service/command/request/CreateVotePostRequest.java
@@ -1,11 +1,14 @@
 package fun.domain.vote.post.service.command.request;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record CreateVotePostRequest(
         String title,
         String content,
         Long tagId,
-        LocalDateTime localDateTime
+        List<String> voteItemTitles,
+        LocalDateTime localDateTime,
+        boolean isEnableComments
 ) {
 }

--- a/src/test/java/fun/domain/auth/controller/command/AuthCommandControllerTest.java
+++ b/src/test/java/fun/domain/auth/controller/command/AuthCommandControllerTest.java
@@ -1,5 +1,7 @@
 package fun.domain.auth.controller.command;
 
+import fun.common.auth.AuthAccessToken;
+import fun.common.auth.AuthRefreshToken;
 import fun.domain.auth.domain.AuthSocialType;
 import fun.domain.auth.domain.RefreshToken;
 import fun.domain.auth.service.command.response.TokenResponse;
@@ -9,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import static fun.ApiUrl.POST_JOIN_SOCIAL_MEMBER;
 import static fun.ApiUrl.PUT_NEW_TOKENS;
+import static fun.common.auth.AuthRefreshToken.AUTHORIZATION_REFRESH_TOKEN;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.when;
@@ -31,6 +34,7 @@ class AuthCommandControllerTest extends ControllerTestConfig {
     @Test
     void success_createMemberAndReturnToken() throws Exception {
         // when
+        mockingAuthAccessToken(new AuthAccessToken(1L));
         when(
                 authCommandService.createTokens(
                         any(AuthSocialType.class),
@@ -66,6 +70,7 @@ class AuthCommandControllerTest extends ControllerTestConfig {
     @Test
     void success_recreateTokens() throws Exception {
         // when
+        mockingAuthRefreshToken(new AuthRefreshToken("newSignedRefreshToken"));
         when(
                 authCommandService.recreateTokens(any(RefreshToken.class))
         ).thenReturn(
@@ -75,7 +80,7 @@ class AuthCommandControllerTest extends ControllerTestConfig {
         // expect
         mockMvc.perform(
                         put(PUT_NEW_TOKENS)
-                                .header("RefreshToken", "signedRefreshToken")
+                                .header(AUTHORIZATION_REFRESH_TOKEN, "signedRefreshToken")
                 )
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(APPLICATION_JSON))

--- a/src/test/java/fun/domain/auth/service/command/AuthCommandServiceTest.java
+++ b/src/test/java/fun/domain/auth/service/command/AuthCommandServiceTest.java
@@ -1,6 +1,7 @@
 package fun.domain.auth.service.command;
 
 import fun.domain.auth.domain.AccessTokenSignerStub;
+import fun.domain.auth.domain.AuthMember;
 import fun.domain.auth.domain.AuthSocialType;
 import fun.domain.auth.domain.RefreshToken;
 import fun.domain.auth.domain.RefreshTokenSignerStub;
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static fun.domain.auth.service.command.token.SocialAccessTokenProviderStub.ONE_SOCIAL_ACCESS_TOKEN;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 class AuthCommandServiceTest extends ServiceTestConfig {
@@ -48,15 +50,24 @@ class AuthCommandServiceTest extends ServiceTestConfig {
     @Test
     void success_recreateTokens() {
         // given
+        final RefreshToken oldRefreshToken = new RefreshToken("refreshToken");
+        authMemberRepository.save(
+                new AuthMember(
+                        1L,
+                        ONE_SOCIAL_ACCESS_TOKEN.toSocialAccessToken(),
+                        oldRefreshToken,
+                        AuthSocialType.KAKAO,
+                        1L
+                )
+        );
+
         final TokenResponse oldTokens = authCommandService.createTokens(
                 AuthSocialType.KAKAO,
                 SocialAccessTokenProviderCompositeStub.ONE_AUTH_CODE
         );
 
         // when
-        final TokenResponse actual = authCommandService.recreateTokens(
-                new RefreshToken(oldTokens.refreshToken())
-        );
+        final TokenResponse actual = authCommandService.recreateTokens(oldRefreshToken);
 
         // expect
         assertSoftly(softly -> {

--- a/src/test/java/fun/domain/vote/item/domain/VoteItemTest.java
+++ b/src/test/java/fun/domain/vote/item/domain/VoteItemTest.java
@@ -1,0 +1,39 @@
+package fun.domain.vote.item.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class VoteItemTest {
+
+    @DisplayName("[SUCCESS] 투표 항목이 속할 투표 게시글을 지정한다.")
+    @Test
+    void success_assignVotePost() {
+        // given
+        final VoteItem voteItem = new VoteItem("투표 항목 내용");
+
+        // when
+        voteItem.assignVotePost(1L);
+
+        // then
+        assertThat(voteItem.getVotePostId()).isPositive();
+    }
+
+    @DisplayName("[EXCEPTION] 투표 항목이 이미 투표 게시글에 속해 있을 경우 새로운 투표 게시글에 지정될 수 없다.")
+    @Test
+    void exception_assignVotePost() {
+        // given
+        final VoteItem voteItem = new VoteItem("투표 항목 내용");
+
+        // when
+        voteItem.assignVotePost(1L);
+        voteItem.assignVotePost(1L);
+
+        // then
+        assertThatThrownBy(() ->
+                voteItem.assignVotePost(1L)
+        ).isInstanceOf(IllegalStateException.class);
+    }
+}

--- a/src/test/java/fun/domain/vote/item/domain/VoteItemTest.java
+++ b/src/test/java/fun/domain/vote/item/domain/VoteItemTest.java
@@ -29,7 +29,6 @@ class VoteItemTest {
 
         // when
         voteItem.assignVotePost(1L);
-        voteItem.assignVotePost(1L);
 
         // then
         assertThatThrownBy(() ->

--- a/src/test/java/fun/domain/vote/post/controller/command/VotePostCommandControllerTest.java
+++ b/src/test/java/fun/domain/vote/post/controller/command/VotePostCommandControllerTest.java
@@ -1,0 +1,76 @@
+package fun.domain.vote.post.controller.command;
+
+import fun.domain.vote.post.service.command.request.CreateVotePostRequest;
+import fun.testconfig.ControllerTestConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static fun.ApiUrl.POST_VOTE_POST_CREATE;
+import static fun.common.auth.AuthAccessToken.AUTHORIZATION_ACCESS_TOKEN;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class VotePostCommandControllerTest extends ControllerTestConfig {
+
+    @DisplayName("[SUCCESS] 소셜 인증 코드를 이용하여 회원가입[신규] 후 토큰(액세스, 리프래시)을 반환한다.")
+    @Test
+    void success_createVotePost() throws Exception {
+        // given
+        final CreateVotePostRequest createVotePostRequest = new CreateVotePostRequest(
+                "투표 게시글 제목",
+                "투표 게시글 내용",
+                1L,
+                List.of("투표 항목 내용1", "투표 항목 내용2"),
+                LocalDateTime.now().plusHours(24),
+                true
+        );
+
+        // when
+        when(
+                votePostCommandService.createVotePost(
+                        any(Long.class),
+                        any(CreateVotePostRequest.class)
+                )
+        ).thenReturn(
+                1L
+        );
+
+        // then
+        mockMvc.perform(
+                        post(POST_VOTE_POST_CREATE)
+                                .header(AUTHORIZATION_ACCESS_TOKEN, "Bearer accessToken")
+                                .content(objectMapper.writeValueAsString(createVotePostRequest))
+                                .accept(APPLICATION_JSON)
+                                .contentType(APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(redirectedUrlPattern("/api/v1/posts/**"))
+                .andDo(restDocs.document(
+                        requestHeaders(
+                                headerWithName(AUTHORIZATION_ACCESS_TOKEN).description("서명된 액세스 토큰")
+                        ),
+                        requestFields(
+                                fieldWithPath("title").type(String.class).description("투표 게시글 제목"),
+                                fieldWithPath("content").type(String.class).description("투표 게시글 내용"),
+                                fieldWithPath("tagId").type(Long.class).description("투표 게시글 태그"),
+                                fieldWithPath("voteItemTitles").type(Arrays.class).description("투표 항목 내용 목록"),
+                                fieldWithPath("localDateTime").type(LocalDateTime.class).description("투표 게시글 마감 기한"),
+                                fieldWithPath("isEnableComments").type(Boolean.class).description("투표 게시글 실시간 댓글 true/false")
+                        )
+                ));
+    }
+}

--- a/src/test/java/fun/domain/vote/post/domain/VotePostTest.java
+++ b/src/test/java/fun/domain/vote/post/domain/VotePostTest.java
@@ -1,10 +1,11 @@
 package fun.domain.vote.post.domain;
 
+import fun.domain.vote.item.domain.VoteItem;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
-import java.util.Collections;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -19,8 +20,7 @@ class VotePostTest {
                 "투표 게시글 제목",
                 "투표 게시글 내용",
                 new DueDate(LocalDateTime.now().plusHours(24)),
-                new VoteTag(Tag.SCIENCE),
-                Collections.emptyList()
+                new VoteTag(Tag.SCIENCE)
         );
 
         // when
@@ -38,13 +38,32 @@ class VotePostTest {
                 "투표 게시글 제목",
                 "투표 게시글 내용",
                 new DueDate(LocalDateTime.now().plusHours(24)),
-                new VoteTag(Tag.SCIENCE),
-                Collections.emptyList()
+                new VoteTag(Tag.SCIENCE)
         );
 
         // expect
         assertThatThrownBy(() ->
                 actual.assignHost(1L, new VoteAssignHostValidatorFailStub())
         ).isInstanceOf(IllegalStateException.class);
+    }
+
+    @DisplayName("[SUCCESS] 투표 게시글에 투표 항목 할당을 성공한다.")
+    @Test
+    void success_addVoteItem() {
+        // given
+        final VotePost actual = new VotePost(
+                "투표 게시글 제목",
+                "투표 게시글 내용",
+                new DueDate(LocalDateTime.now().plusHours(24)),
+                new VoteTag(Tag.SCIENCE)
+        );
+
+        // when
+        final VoteItem expected1 = new VoteItem("투표 항목 내용1");
+        final VoteItem expected2 = new VoteItem("투표 항목 내용2");
+        actual.addVoteItems(List.of(expected1, expected2));
+
+        // then
+        assertThat(actual.getVoteItems()).containsExactly(expected1, expected2);
     }
 }


### PR DESCRIPTION
### 작업 대상

---

<!-- 아래 작성 -->

#7

### 작업 내용

---

<!-- 아래 작성 -->

- AuthAccessArgumentResolver, AuthRefreshArgumentResolver 수정
  - 토큰을 파싱한 값을 내부에서 가져오는 로직 수정
- VotePost 저장시 VoteItem 동시에 저장하도록 개발

### 참고

---

<!-- 아래 작성 -->
